### PR TITLE
Read killed process exit status to prevent zombie processes

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -130,7 +130,7 @@ func runner(command string, buildDone chan bool) {
 				log.Fatal("Could not kill child process. Aborting due to danger of infinite forks.")
 			}
 
-			_,werr := currentProcess.Wait()
+			_, werr := currentProcess.Wait()
 
 			if werr != nil {
 				log.Fatal("Could not wait for child process. Aborting due to danger of infinite forks.")


### PR DESCRIPTION
Killed processes wait around until their exit status is read. This leads to zombie processes accumulating as you develop using CommandDaemon. Reading the exit status prevents this, and also makes sure that the previous command is dead and has released its resources before the new command is executed.

There is a danger introduced, that if the command refuses to be killed, then we block forever at the Wait(). It might be a good idea to add a timeout, but then that gets into what to do next. Exit CompileDaemon? Send an unblockable fatal signal to the child? I think that should be left to be handled if it ever comes up.
