### PR TITLE
Add support for -on-build= and -on-fail=

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Usage:
 |`-exclude=…` | none | Exclude files matching this glob pattern, e.g. ".#*" ignores emacs temporary files. You may have multiples of this flag.|
 |`-include=…` | none | Include files whose last path component matches this glob pattern. You may have multiples of this flag.|
 |`-pattern=…` | (.+\\.go&#124;.+\\.c)$ | A regular expression which matches the files to watch. The default watches *.go* and *.c* files.|
-
+|`-on-build=…` | *none* | Execute this command after a successful build. You may have multiples of this flag. Unlike `-command` these commands are expected to terminate.|
+|`-on-fail=…` | *none* | Execute this command after a failed build. You may have multiples of this flag.|
+ 
 ## Examples
 
 In its simplest form, the defaults will do. With the current working directory set


### PR DESCRIPTION
This adds command line options for actions to be executed after successful builds and failed builds.

It lets you ring a terminal bell, or print an attention getting banner on a failed build.

It is also useful if you are working on a service for which you give a "restart" command rather than running it directly. -command does not appreciate commands which exit. For instance, at the moment I'm using

```
CompileDaemon … -on-build="sudo systemctl restart mydaemonname"
```
