### PR TITLE
Fix deadlock after failed build

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -100,7 +100,7 @@ var (
 	flag_directory    = flag.String("directory", ".", "Directory to watch for changes")
 	flag_pattern      = flag.String("pattern", FilePattern, "Pattern of watched files")
 	flag_command      = flag.String("command", "", "Command to run and restart after build")
-	flag_command_stop  = flag.Bool("command-stop", false, "Stop command before building")
+	flag_command_stop = flag.Bool("command-stop", false, "Stop command before building")
 	flag_recursive    = flag.Bool("recursive", true, "Watch all dirs. recursively")
 	flag_build        = flag.String("build", "go build", "Command to rebuild after changes")
 	flag_color        = flag.Bool("color", false, "Colorize output for CompileDaemon status messages")
@@ -108,7 +108,7 @@ var (
 	flag_gracefulkill = flag.Bool("graceful-kill", false, "Gracefully attempt to kill the child process by sending a SIGTERM first")
 
 	// initialized in main() due to custom type.
-	flag_excludedDirs globList
+	flag_excludedDirs  globList
 	flag_excludedFiles globList
 	flag_includedFiles globList
 )
@@ -161,7 +161,7 @@ func matchesPattern(pattern *regexp.Regexp, file string) bool {
 // Accept build jobs and start building when there are no jobs rushing in.
 // The inrush protection is WorkDelay milliseconds long, in this period
 // every incoming job will reset the timer.
-func builder(jobs <-chan string,buildStarted chan<- struct{}, buildDone chan<- struct{}) {
+func builder(jobs <-chan string, buildStarted chan<- struct{}, buildDone chan<- struct{}) {
 	createThreshold := func() <-chan time.Time {
 		return time.After(time.Duration(WorkDelay * time.Millisecond))
 	}
@@ -174,7 +174,7 @@ func builder(jobs <-chan string,buildStarted chan<- struct{}, buildDone chan<- s
 			threshold = createThreshold()
 		case <-threshold:
 			buildStarted <- struct{}{}
-			
+
 			if build() {
 				buildDone <- struct{}{}
 			}
@@ -236,7 +236,7 @@ func startCommand(command string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr i
 
 // Run the command in the given string and restart it after
 // a message was received on the buildDone channel.
-func runner(command string,buildStarted <-chan struct{}, buildDone <-chan struct{}) {
+func runner(command string, buildStarted <-chan struct{}, buildDone <-chan struct{}) {
 	var currentProcess *os.Process
 	pipeChan := make(chan io.ReadCloser)
 
@@ -314,9 +314,9 @@ func killProcessGracefully(process *os.Process) {
 	}
 }
 
-func flusher(buildStarted <-chan struct{},buildDone <-chan struct{}) {
-	for {		
-		<-buildStarted		
+func flusher(buildStarted <-chan struct{}, buildDone <-chan struct{}) {
+	for {
+		<-buildStarted
 		<-buildDone
 	}
 }
@@ -376,12 +376,12 @@ func main() {
 	buildDone := make(chan struct{})
 	buildStarted := make(chan struct{})
 
-	go builder(jobs, buildStarted,buildDone)
+	go builder(jobs, buildStarted, buildDone)
 
 	if *flag_command != "" {
-		go runner(*flag_command, buildStarted,buildDone)
+		go runner(*flag_command, buildStarted, buildDone)
 	} else {
-		go flusher(buildStarted,buildDone)
+		go flusher(buildStarted, buildDone)
 	}
 
 	for {


### PR DESCRIPTION
Steps to reproduce:
1. Run `go run daemon.go process_posix.go -build="false" -command="pwd"`
2. Save multiple times daemon.go
3. PROFIT!

Example of panic after detected deadlock:
```
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan send]:
main.main()
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:395 +0x903

goroutine 5 [chan send]:
github.com/howeyc/fsnotify.(*Watcher).readEvents(0x82033a000)
	/Users/dmage/.go/src/github.com/howeyc/fsnotify/fsnotify_bsd.go:368 +0xb96
created by github.com/howeyc/fsnotify.NewWatcher
	/Users/dmage/.go/src/github.com/howeyc/fsnotify/fsnotify_bsd.go:105 +0x57c

goroutine 6 [chan send]:
github.com/howeyc/fsnotify.(*Watcher).purgeEvents(0x82033a000)
	/Users/dmage/.go/src/github.com/howeyc/fsnotify/fsnotify.go:44 +0x1cd
created by github.com/howeyc/fsnotify.NewWatcher
	/Users/dmage/.go/src/github.com/howeyc/fsnotify/fsnotify_bsd.go:106 +0x59e

goroutine 17 [chan send]:
main.builder(0x8203ca060, 0x8203ca120, 0x8203ca0c0)
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:176 +0xff
created by main.main
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:379 +0x6d6

goroutine 18 [chan receive]:
main.runner(0x7fff5fbff768, 0x3, 0x8203ca120, 0x8203ca0c0)
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:248 +0xd5
created by main.main
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:382 +0x737

goroutine 19 [chan receive]:
main.logger(0x8203ca180)
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:206 +0x53
created by main.runner
	/Users/dmage/src/github.com/dmage/CompileDaemon/daemon.go:243 +0x7a
exit status 2
```