### PR TITLE
Added signal listener to handle proper cleanup.

### DIFF
--- a/process_posix.go
+++ b/process_posix.go
@@ -7,6 +7,12 @@ import (
 	"syscall"
 )
 
+var fatalSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGQUIT,
+}
+
 func terminateGracefully(process *os.Process) error {
 	return process.Signal(syscall.SIGTERM)
 }

--- a/process_windows.go
+++ b/process_windows.go
@@ -5,6 +5,11 @@ import (
 	"os"
 )
 
+var fatalSignals = []os.Signal{
+	os.Interrupt,
+	os.Kill,
+}
+
 func terminateGracefully(process *os.Process) error {
 	return errors.New("terminateGracefully not implemented on windows")
 }


### PR DESCRIPTION
Fixes issue #12 for SIGINT, SIGTERM.  ``kill -s INT <pid>`` and ``kill <pid>`` no longer orphans the child process.