### PR TITLE
:pencil2: fix invalid format

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -288,7 +288,7 @@ func runner(commandTemplate string, buildStarted <-chan string, buildSuccess <-c
 		cmd, stdoutPipe, stderrPipe, err := startCommand(command)
 
 		if err != nil {
-			log.Fatal(failColor("Could not start command:", err))
+			log.Fatal(failColor("Could not start command: %s", err))
 		}
 
 		pipeChan <- stdoutPipe


### PR DESCRIPTION
Hi,

This PR fixes a little formatting bug.
*before*
```console
Could not start command:%!(EXTRA *errors.errorString=....
```
*after*
```console
Could not start command: can't start command...
```