### PR TITLE
If using -command-stop don't restart on build fail

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -284,7 +284,9 @@ func runner(commandTemplate string, buildStarted <-chan string, buildSuccess <-c
 		}
 		if *flag_command_stop {
 			log.Println(okColor("Command stopped. Waiting for build to complete."))
-			<-buildSuccess
+			if !<-buildSuccess {
+				continue
+			}
 		}
 
 		log.Println(okColor("Restarting the given command."))


### PR DESCRIPTION
When running a web serivce it is nice to know if the build breaks by
stopping the service. The -command-stop seems like it should make this
use case work, but it restarted the command regards of the success of
the build. This fix does not restart the process if the build failed.