### PR TITLE
allow -command option to work with programs that run once and exit

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -315,7 +315,7 @@ func killProcessHard(process *os.Process) {
 	log.Println(okColor("Hard stopping the current process.."))
 
 	if err := process.Kill(); err != nil {
-		log.Fatal(failColor("Could not kill child process. Aborting due to danger of infinite forks."))
+		log.Println(failColor("Warning: could not kill child process.  It may have already exited."))
 	}
 
 	if _, err := process.Wait(); err != nil {


### PR DESCRIPTION
Previously, CompileDaemon encountered a fatal error if the command it had launched could not be found and killed.  Now that situation is treated as a warning only, since it may indicate that a command expected to exit has already exited.