### PR TITLE
Update fsnotify dependency

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -77,7 +77,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 )
 
 // Milliseconds to wait for the next job to begin after a file change


### PR DESCRIPTION
The used fsnotify dependency is not available:

```
curl gopkg.in/fsnotify.v1
GitHub repository at https://github.com/go-fsnotify/fsnotify has no branch or tag "v1", "v1.N" or "v1.N.M"
```