### PR TITLE
Add dep versioning via `go mod`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ You can use the `go` tool to install `CompileDaemon`:
 
 	go get github.com/githubnemo/CompileDaemon
 
+## Development
+
+You need to use Go 1.11 or higher to build Compile Daemon, and you need to set
+the env var `GO111MODULE=on`, which enables you to develop outside of
+`$GOPATH/src`.
+
 ## Command Line Options
 
 |Option    | Default     | Description|

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/githubnemo/CompileDaemon
+
+go 1.11
+
+require (
+	github.com/fatih/color v1.9.0
+	github.com/fsnotify/fsnotify v1.4.9
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This change pins direct dependencies to specific versions, and enables
developing and building this project outside of `$GOPATH`.

This change was automatically generated via:

```
$ go mod init github.com/githubnemo/CompileDaemon
$ go mod tidy
```

Since this feature was introduced in Go 1.11, this is now the minimum Go version
to compile this project; however, note that since the Go project only maintains
the 2 most recent major releases [1], and the two most recent releases are Go
1.13 and 1.14, any releases up to and including Go 1.12 are no longer supported
anyway.

This change also requires setting the env variable `GO111MODULE=on` to work.

[1] https://golang.org/doc/devel/release.html says:

> ## Release Policy
>
> Each major Go release is supported until there are two newer major releases.
> For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was
> supported until the Go 1.8 release. [...]
>
> ## go1.14 (released 2020/02/25)