### PR TITLE
Add polling-style file watch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ the env var `GO111MODULE=on`, which enables you to develop outside of
 |`-include=…` | none | Include files whose last path component matches this glob pattern. You may have multiples of this flag.|
 |`-pattern=…` | (.+\\.go&#124;.+\\.c)$ | A regular expression which matches the files to watch. The default watches *.go* and *.c* files.|
 | | | **file watch** |
-|`-polling=…` | false | Which method to detect file changes.
+|`-polling=…` | false | Use polling instead of FS notifications to detect changes. Default is false
+|`-polling-interval=…` | 100 | Milliseconds of interval between polling file changes when polling option is selected
 | | | **misc** |
 |`-color=_` | false | Colorize the output of the daemon's status messages. |
 |`-log-prefix=_` | true | Prefix all child process output with stdout/stderr labels and log timestamps. |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ the env var `GO111MODULE=on`, which enables you to develop outside of
 |`-exclude=…` | none | Exclude files matching this glob pattern, e.g. ".#*" ignores emacs temporary files. You may have multiples of this flag.|
 |`-include=…` | none | Include files whose last path component matches this glob pattern. You may have multiples of this flag.|
 |`-pattern=…` | (.+\\.go&#124;.+\\.c)$ | A regular expression which matches the files to watch. The default watches *.go* and *.c* files.|
+| | | **file watch** |
+|`-polling=…` | false | Which method to detect file changes.
 | | | **misc** |
 |`-color=_` | false | Colorize the output of the daemon's status messages. |
 |`-log-prefix=_` | true | Prefix all child process output with stdout/stderr labels and log timestamps. |

--- a/daemon.go
+++ b/daemon.go
@@ -391,8 +391,19 @@ func main() {
 		log.Fatal("Graceful termination is not supported on your platform.")
 	}
 
+	pattern := regexp.MustCompile(*flagPattern)
 
-	watcher, err := NewWatcher(*flagPolling)
+	cfg := &WatcherConfig{
+		flagVerbose:       *flagVerbose,
+		flagRecursive:     *flagRecursive,
+		flagPolling:       *flagPolling,
+		flagDirectories:   flagDirectories,
+		flagExcludedDirs:  flagExcludedDirs,
+		flagExcludedFiles: flagExcludedFiles,
+		flagIncludedFiles: flagIncludedFiles,
+		pattern:           pattern,
+	}
+	watcher, err := NewWatcher(cfg)
 
 	if err != nil {
 		log.Fatal(err)
@@ -400,9 +411,7 @@ func main() {
 
 	defer watcher.Close()
 
-	pattern := regexp.MustCompile(*flagPattern)
-
-	err = watcher.AddFiles(pattern)
+	err = watcher.AddFiles()
 	if err != nil {
 		log.Fatal("watcher.Addfiles():", err)
 	}
@@ -419,5 +428,5 @@ func main() {
 		go flusher(buildStarted, buildSuccess)
 	}
 
-	watcher.Watch(jobs, pattern) // start watching files
+	watcher.Watch(jobs) // start watching files
 }

--- a/daemon.go
+++ b/daemon.go
@@ -84,9 +84,6 @@ import (
 // Milliseconds to wait for the next job to begin after a file change
 const WorkDelay = 900
 
-// Milliseconds of interval between polling file changes when polling option is selected
-const PollingInterval = 100
-
 // Default pattern to match files which trigger a build
 const FilePattern = `(.+\.go|.+\.c)$`
 
@@ -124,6 +121,7 @@ var (
 	flagGracefulTimeout = flag.Uint("graceful-timeout", 3, "Duration (in seconds) to wait for graceful kill to complete")
 	flagVerbose         = flag.Bool("verbose", false, "Be verbose about which directories are watched.")
 	flagPolling         = flag.Bool("polling", false, "Use polling method to watch file change instead of fsnotify")
+	flagPollingInterval = flag.Int("polling-interval", 100, "Milliseconds of interval between polling file changes when polling option is selected")
 
 	// initialized in main() due to custom type.
 	flagDirectories   globList
@@ -394,14 +392,15 @@ func main() {
 	pattern := regexp.MustCompile(*flagPattern)
 
 	cfg := &WatcherConfig{
-		flagVerbose:       *flagVerbose,
-		flagRecursive:     *flagRecursive,
-		flagPolling:       *flagPolling,
-		flagDirectories:   flagDirectories,
-		flagExcludedDirs:  flagExcludedDirs,
-		flagExcludedFiles: flagExcludedFiles,
-		flagIncludedFiles: flagIncludedFiles,
-		pattern:           pattern,
+		flagVerbose:         *flagVerbose,
+		flagRecursive:       *flagRecursive,
+		flagPolling:         *flagPolling,
+		flagPollingInterval: *flagPollingInterval,
+		flagDirectories:     flagDirectories,
+		flagExcludedDirs:    flagExcludedDirs,
+		flagExcludedFiles:   flagExcludedFiles,
+		flagIncludedFiles:   flagIncludedFiles,
+		pattern:             pattern,
 	}
 	watcher, err := NewWatcher(cfg)
 

--- a/daemon.go
+++ b/daemon.go
@@ -47,7 +47,7 @@ There are command line options.
 	-pattern=XXX      – Include files whose path matches regexp XXX
 
 	FILE WATCH
-	-polling          - Which method to detect file changes. default is false
+	-polling          - Use polling instead of FS notifications to detect changes. Default is false
 
 	MISC
 	-color            - Enable colorized output
@@ -391,7 +391,6 @@ func main() {
 		log.Fatal("Graceful termination is not supported on your platform.")
 	}
 
-	///////////////////////////////
 
 	watcher, err := NewWatcher(*flagPolling)
 
@@ -403,7 +402,6 @@ func main() {
 
 	pattern := regexp.MustCompile(*flagPattern)
 
-	// add files
 	err = watcher.AddFiles(pattern)
 	if err != nil {
 		log.Fatal("watcher.Addfiles():", err)

--- a/daemon.go
+++ b/daemon.go
@@ -48,6 +48,7 @@ There are command line options.
 
 	FILE WATCH
 	-polling          - Use polling instead of FS notifications to detect changes. Default is false
+	-polling-interval - Milliseconds of interval between polling file changes when polling option is selected
 
 	MISC
 	-color            - Enable colorized output

--- a/daemon.go
+++ b/daemon.go
@@ -84,8 +84,8 @@ import (
 // Milliseconds to wait for the next job to begin after a file change
 const WorkDelay = 900
 
-// ...
-const PollingInterval = "100ms"
+// Milliseconds of interval between polling file changes when polling option is selected
+const PollingInterval = 100
 
 // Default pattern to match files which trigger a build
 const FilePattern = `(.+\.go|.+\.c)$`

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.11
 require (
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/radovskyb/watcher v1.0.7
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/daangn/CompileDaemon
+module github.com/githubnemo/CompileDaemon
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/githubnemo/CompileDaemon
+module github.com/daangn/CompileDaemon
 
 go 1.11
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
+github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=

--- a/watcher.go
+++ b/watcher.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"github.com/fsnotify/fsnotify"
+	pollingWatcher "github.com/radovskyb/watcher"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+type FileWatcher interface {
+	Close() error
+	AddFiles(pattern *regexp.Regexp) error
+	Watch(jobs chan<- string, pattern *regexp.Regexp)
+}
+
+type NotifyWatcher struct {
+	watcher *fsnotify.Watcher
+}
+
+func (n NotifyWatcher) Close() error {
+	return n.watcher.Close()
+}
+
+func (n NotifyWatcher) AddFiles(pattern *regexp.Regexp) error {
+	for _, flagDirectory := range flagDirectories {
+		if *flagRecursive == true {
+			err := filepath.Walk(flagDirectory, func(path string, info os.FileInfo, err error) error {
+				if err == nil && info.IsDir() {
+					if flagExcludedDirs.Matches(path) {
+						return filepath.SkipDir
+					} else {
+						if *flagVerbose {
+							log.Printf("Watching directory '%s' for changes.\n", path)
+						}
+						return n.watcher.Add(path)
+					}
+				}
+				return err
+			})
+
+			if err != nil {
+				return fmt.Errorf("filepath.Walk(): %v", err)
+			}
+
+			if err := n.watcher.Add(flagDirectory); err != nil {
+				return fmt.Errorf("NotifyWatcher.Add(): %v", err)
+			}
+		} else {
+			if err := n.watcher.Add(flagDirectory); err != nil {
+				return fmt.Errorf("NotifyWatcher.Add(): %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (n NotifyWatcher) Watch(jobs chan<- string, pattern *regexp.Regexp) {
+	for {
+		select {
+		case ev := <-n.watcher.Events:
+			if ev.Op&fsnotify.Remove == fsnotify.Remove || ev.Op&fsnotify.Write == fsnotify.Write || ev.Op&fsnotify.Create == fsnotify.Create {
+				base := filepath.Base(ev.Name)
+
+				// Assume it is a directory and track it.
+				if *flagRecursive == true && !flagExcludedDirs.Matches(ev.Name) {
+					n.watcher.Add(ev.Name)
+				}
+
+				if flagIncludedFiles.Matches(base) || matchesPattern(pattern, ev.Name) {
+					if !flagExcludedFiles.Matches(base) {
+						jobs <- ev.Name
+					}
+				}
+			}
+
+		case err := <-n.watcher.Errors:
+			if v, ok := err.(*os.SyscallError); ok {
+				if v.Err == syscall.EINTR {
+					continue
+				}
+				log.Fatal("watcher.Error: SyscallError:", v)
+			}
+			log.Fatal("watcher.Error:", err)
+		}
+	}
+}
+
+type PollingWatcher struct {
+	watcher *pollingWatcher.Watcher
+}
+
+func (p PollingWatcher) Close() error {
+	p.watcher.Close()
+	return nil
+}
+
+func (p PollingWatcher) AddFiles(pattern *regexp.Regexp) error {
+	p.watcher.AddFilterHook(pollingWatcher.RegexFilterHook(pattern, false))
+
+	for _, flagDirectory := range flagDirectories {
+		if *flagRecursive == true {
+			if err := p.watcher.AddRecursive(flagDirectory); err != nil {
+				return fmt.Errorf("PollingWatcher.AddFiles(): %v", err)
+			}
+		} else {
+			if err := p.watcher.Add(flagDirectory); err != nil {
+				return fmt.Errorf("NotifyWatcher.AddFiles(): %v", err)
+			}
+		}
+	}
+
+	if *flagVerbose {
+		for path, f := range p.watcher.WatchedFiles() {
+			fmt.Printf("Watching %s: %s\n", path, f.Name())
+		}
+	}
+	return nil
+}
+
+func (p PollingWatcher) Watch(jobs chan<- string, pattern *regexp.Regexp) {
+	// Parse the interval string into a time.Duration.
+	parsedInterval, err := time.ParseDuration(PollingInterval)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Start the watching process.
+	go func() {
+		if err := p.watcher.Start(parsedInterval); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	for {
+		select {
+		case event := <-p.watcher.Event:
+			if *flagVerbose {
+				// Print the event's info.
+				fmt.Println(event)
+			}
+
+			base := filepath.Base(event.Path)
+
+			if flagIncludedFiles.Matches(base) || matchesPattern(pattern, event.Path) {
+				if !flagExcludedFiles.Matches(base) {
+					jobs <- event.String()
+				}
+			}
+		case err := <-p.watcher.Error:
+			if err == pollingWatcher.ErrWatchedFileDeleted {
+				fmt.Println(err)
+				continue
+			}
+			log.Fatalln(err)
+		case <-p.watcher.Closed:
+			return
+		}
+	}
+}
+
+func NewWatcher(usePolling bool) (FileWatcher, error) {
+	if usePolling {
+		w := pollingWatcher.New()
+		return PollingWatcher{
+			watcher: w,
+		}, nil
+	} else {
+		w, err := fsnotify.NewWatcher()
+		if err != nil {
+			return nil, err
+		}
+		return NotifyWatcher{
+			watcher: w,
+		}, nil
+	}
+}


### PR DESCRIPTION
As discussed in #44 and #47, file watch via `fsnotify` is troublesome in some Mac OS X or Docker environment.

So, I implemented optional polling-style file watch mechanism to avoid horrible file system issues as suggested in #44.

It still has optional parameter to choose either polling or fsevent, so non-OS X user won't be affected by this change.
