### PR TITLE
refact: replace filepath.Walk into filepath.WalkDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can use the `go` tool to install `CompileDaemon`:
 
 ## Development
 
-You need to use Go 1.11 or higher to build Compile Daemon, and you need to set
+You need to use Go 1.16 or higher to build Compile Daemon, and you need to set
 the env var `GO111MODULE=on`, which enables you to develop outside of
 `$GOPATH/src`.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/githubnemo/CompileDaemon
 
-go 1.11
+go 1.16
 
 require (
 	github.com/fatih/color v1.9.0

--- a/watcher.go
+++ b/watcher.go
@@ -3,14 +3,15 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/fsnotify/fsnotify"
-	pollingWatcher "github.com/radovskyb/watcher"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"syscall"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
+	pollingWatcher "github.com/radovskyb/watcher"
 )
 
 func directoryShouldBeTracked(cfg *WatcherConfig, path string) bool {
@@ -171,8 +172,8 @@ func addFiles(fw FileWatcher) error {
 	cfg := fw.getConfig()
 	for _, flagDirectory := range cfg.flagDirectories {
 		if cfg.flagRecursive == true {
-			err := filepath.Walk(flagDirectory, func(path string, info os.FileInfo, err error) error {
-				if err == nil && info.IsDir() {
+			err := filepath.WalkDir(flagDirectory, func(path string, entry os.DirEntry, err error) error {
+				if err == nil && entry.IsDir() {
 					if cfg.flagExcludedDirs.Matches(path) {
 						return filepath.SkipDir
 					} else {


### PR DESCRIPTION
From Go 1.16 docs:

> Walk is less efficient than WalkDir, introduced in Go 1.16, which avoids calling os.Lstat on every visited file or directory.
>
> The differences between WalkDirFunc compared to filepath.WalkFunc are:
>
> * The second argument has type fs.DirEntry instead of fs.FileInfo.
> * The function is called before reading a directory, to allow SkipDir to bypass the directory read entirely.
> * If a directory read fails, the function is called a second time for that directory to report the error.

This change would make some performance improvements when lots of directories are matched with given `flagExcludedDirs` pattern.

Currently, CompileDaemon requires Go 1.11 or higher but `WalkDir` are introduced in Go 1.16. Thus, Go 1.16 or higher version will be needed after merging this PR.

Feel free to close this PR if you don't want to update Go version now.