### PR TITLE
Bump fsnotify to bump sys for go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.11
 
 require (
 	github.com/fatih/color v1.9.0
-	github.com/fsnotify/fsnotify v1.4.9
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/radovskyb/watcher v1.0.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -10,6 +10,6 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
I'm using go 1.18 on macOS, and go install fails with below message:

```
$ go install github.com/githubnemo/CompileDaemon@latest
# golang.org/x/sys/unix
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
../../go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_amd64.go:121:3: too many errors
```

This is [caused by old x/sys library](https://github.com/golang/go/issues/51091#issuecomment-1033334340).

Using [depth](https://github.com/KyleBanks/depth) dependency tree visualizer, I found old fsnotify module references old x/sys module.

So just I bumped it :)