### PR TITLE
Set pgid and kill the process group on posix

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -77,6 +77,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fatih/color"
@@ -259,6 +260,7 @@ func logger(pipeChan <-chan io.ReadCloser) {
 func startCommand(command string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, err error) {
 	args := strings.Split(command, " ")
 	cmd = exec.Command(args[0], args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if *flagRunDir != "" {
 		cmd.Dir = *flagRunDir
@@ -354,7 +356,7 @@ func killProcess(process *os.Process) {
 func killProcessHard(process *os.Process) {
 	log.Println(okColor("Hard stopping the current process.."))
 
-	if err := process.Kill(); err != nil {
+	if err := terminateHard(process); err != nil {
 		log.Println(failColor("Warning: could not kill child process.  It may have already exited."))
 	}
 

--- a/process_posix.go
+++ b/process_posix.go
@@ -14,7 +14,11 @@ var fatalSignals = []os.Signal{
 }
 
 func terminateGracefully(process *os.Process) error {
-	return process.Signal(syscall.SIGTERM)
+	return syscall.Kill(-process.Pid, syscall.SIGTERM)
+}
+
+func terminateHard(process *os.Process) error {
+	return syscall.Kill(-process.Pid, syscall.SIGKILL)
 }
 
 func gracefulTerminationPossible() bool {

--- a/process_windows.go
+++ b/process_windows.go
@@ -10,6 +10,10 @@ var fatalSignals = []os.Signal{
 	os.Kill,
 }
 
+func terminateHard(process *os.Process) error {
+	return process.Kill()
+}
+
 func terminateGracefully(process *os.Process) error {
 	return errors.New("terminateGracefully not implemented on windows")
 }


### PR DESCRIPTION
See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for a detailed explanation of how this works. For now this only implemented for posix and these changes should have no effect on windows.
This fixes #65 and makes the script in #72 work (without this fix the script would be terminated on re-compile, but the go executable would continue to run, potentially causing issues with used resources like files and sockets)