### PR TITLE
Switch to go install for CompileDaemon with version control (@latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
 
 You can use the `go` tool to install `CompileDaemon`:
 
-	go get github.com/githubnemo/CompileDaemon
+	go install github.com/githubnemo/CompileDaemon@latest
 
 ## Development
 


### PR DESCRIPTION
Fixes #92 

Description:
This PR updates the method used to install CompileDaemon by switching from `go get` to `go install` with explicit version control (@latest).


Changes Made:
Replaced `go get github.com/githubnemo/CompileDaemon` with `go install github.com/githubnemo/CompileDaemon@latest` in the Installation instruction in readme.